### PR TITLE
Create Portfolio Feature

### DIFF
--- a/docs/create-portfolio/create-porfolio.md
+++ b/docs/create-portfolio/create-porfolio.md
@@ -1,0 +1,55 @@
+# Create Portfolio Feature Documentation
+
+## Overview
+
+The Create Portfolio feature allows users to add new portfolios to their accounts. This document outlines the implementation details, usage, and testing strategies for this feature.
+
+## Implementation
+
+- **Domain Models**: Includes `Portfolio` and `PortfolioDTO` types.
+- **Repository Interface**: `AddPortfolioRepository` abstracts the addition of portfolios.
+- **Use Case**: `CreatePortfolioUseCase` encapsulates the business logic.
+- **Infrastructure**: `PortfolioPostgreSqlRepository` implements the repository interface using PrismaClient.
+
+## API Endpoint
+
+`POST /portfolios`
+
+### Request Body
+
+```json
+{
+  "name": "My Portfolio",
+  "description": "A brief description of my portfolio.",
+  "accountId": "account_id_here"
+}
+``` 
+
+### Response
+
+Success (200 OK):
+
+```json
+{
+  "id": "portfolio_id",
+  "name": "My Portfolio",
+  "description": "A brief description of my portfolio."
+}
+``` 
+
+
+### Error (4XX):
+```json
+{
+   "error": "Error message"
+}
+``` 
+
+
+## Testing
+Unit tests have been added for `PortfolioPostgreSqlRepository`` to ensure functionality. Use `vitest` to run the tests.
+
+## Manual Testing
+- 1 - Ensure the database and application are correctly configured.
+- 2 - Use the provided endpoint to create a portfolio, supplying the required information.
+- 3 - Verify the addition in the database.

--- a/docs/create-portfolio/use-case.md
+++ b/docs/create-portfolio/use-case.md
@@ -1,0 +1,32 @@
+# Use Case: Create Portfolio
+
+## Overview
+
+This document outlines the process of creating a portfolio through the application, encompassing user input validation and automatic association of the portfolio with the user's account. The goal is to offer a seamless and secure way for users to manage their portfolios by leveraging their existing account information.
+
+## Success Flow
+
+### User Initiates Portfolio Creation
+
+- [ ] **Start:** The user selects the "Create Portfolio" option within the application.
+- [ ] **Input Submission:** The user fills in the portfolio creation form, providing the necessary information (e.g., portfolio name, description).
+- [ ] **Validation:** The application validates the provided input against predefined criteria (e.g., the name is not empty).
+
+### Portfolio Creation in the Database
+
+- [ ] **Database Check:** The application checks the user's account validity and permissions for creating a new portfolio.
+- [ ] **Portfolio Record Creation:** Assuming validation success and the user has the necessary permissions, the application creates a new portfolio record associated with the user's account in the database.
+- [ ] **Successful Creation:** The user receives confirmation of the portfolio creation and is redirected to the portfolio management page.
+
+
+
+## Exceptions
+
+- [ ] **Input Validation Failure:** If user input fails validation (e.g., empty portfolio name), the application notifies the user to correct the information.
+- [ ] **Unauthorized Creation Attempt:** If the user attempts to create a portfolio without proper permissions or when not logged in, the application prevents the creation and may log the attempt.
+- [ ] **Database Creation Failure:** If there's an issue during the portfolio record creation in the database (e.g., connection issues, constraints violation), the application logs the error and informs the user to try again later.
+
+## Security
+
+- The application ensures the security of the portfolio creation process, employing best practices for user authentication and authorization.
+- Sensitive user information is protected, and the application only requests the minimum necessary data for portfolio creation.

--- a/prisma/migrations/20240331215051_create_account/migration.sql
+++ b/prisma/migrations/20240331215051_create_account/migration.sql
@@ -2,7 +2,7 @@
 CREATE TABLE "Account" (
     "id" VARCHAR(36) NOT NULL,
     "email" VARCHAR(255) NOT NULL,
-    "name" VARCHAR(255),
+    "name" VARCHAR(255) NOT NULL,
     "image" VARCHAR(255),
 
     CONSTRAINT "Account_pkey" PRIMARY KEY ("id")

--- a/prisma/migrations/20240409111105_add_portfolio_table/migration.sql
+++ b/prisma/migrations/20240409111105_add_portfolio_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "Portfolio" (
+    "id" VARCHAR(36) NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" VARCHAR(255),
+    "accountId" VARCHAR(36) NOT NULL,
+
+    CONSTRAINT "Portfolio_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Portfolio" ADD CONSTRAINT "Portfolio_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ datasource db {
 model Account {
   id         String      @id @default(uuid()) @db.VarChar(36)
   email      String      @unique @db.VarChar(255)
-  name       String?     @db.VarChar(255)
+  name       String      @db.VarChar(255)
   image      String?     @db.VarChar(255)
   portfolios Portfolio[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,8 +14,17 @@ datasource db {
 }
 
 model Account {
-  id    String  @id @default(uuid()) @db.VarChar(36)
-  email String  @unique @db.VarChar(255)
-  name  String? @db.VarChar(255)
-  image String? @db.VarChar(255)
+  id         String      @id @default(uuid()) @db.VarChar(36)
+  email      String      @unique @db.VarChar(255)
+  name       String?     @db.VarChar(255)
+  image      String?     @db.VarChar(255)
+  portfolios Portfolio[]
+}
+
+model Portfolio {
+  id          String  @id @default(uuid()) @db.VarChar(36)
+  name        String
+  description String? @db.VarChar(255)
+  accountId   String  @db.VarChar(36)
+  account     Account @relation(fields: [accountId], references: [id])
 }

--- a/src/domain/contracts/repositories/add-portfolio.ts
+++ b/src/domain/contracts/repositories/add-portfolio.ts
@@ -1,0 +1,13 @@
+import { Portfolio } from "@/domain/models";
+
+type Input = AddPortfolioRepository.Input;
+type Output = AddPortfolioRepository.Output;
+
+export interface AddPortfolioRepository {
+  add: (input: Input) => Promise<Output>;
+}
+
+export namespace AddPortfolioRepository {
+  export type Input = Omit<Portfolio, "id">;
+  export type Output = Portfolio;
+}

--- a/src/domain/contracts/repositories/add-portfolio.ts
+++ b/src/domain/contracts/repositories/add-portfolio.ts
@@ -1,4 +1,4 @@
-import { Portfolio } from "@/domain/models";
+import { Portfolio, PortfolioDTO } from "@/domain/models";
 
 type Input = AddPortfolioRepository.Input;
 type Output = AddPortfolioRepository.Output;
@@ -8,6 +8,6 @@ export interface AddPortfolioRepository {
 }
 
 export namespace AddPortfolioRepository {
-  export type Input = Omit<Portfolio, "id">;
+  export type Input = PortfolioDTO;
   export type Output = Portfolio;
 }

--- a/src/domain/contracts/repositories/index.ts
+++ b/src/domain/contracts/repositories/index.ts
@@ -1,2 +1,3 @@
 export * from "./add-account";
+export * from "./add-portfolio";
 export * from "./load-account-by-email";

--- a/src/domain/entities/create-portfolio.ts
+++ b/src/domain/entities/create-portfolio.ts
@@ -1,0 +1,13 @@
+import { Portfolio } from "@/domain/models";
+
+type Input = CreatePortfolio.Input;
+type Output = CreatePortfolio.Output;
+
+export interface CreatePortfolio {
+  create: (input: Input) => Promise<Output>;
+}
+
+export namespace CreatePortfolio {
+  export type Input = Omit<Portfolio, "id">;
+  export type Output = Portfolio;
+}

--- a/src/domain/entities/create-portfolio.ts
+++ b/src/domain/entities/create-portfolio.ts
@@ -1,4 +1,4 @@
-import { Portfolio } from "@/domain/models";
+import { Portfolio, PortfolioDTO } from "@/domain/models";
 
 type Input = CreatePortfolio.Input;
 type Output = CreatePortfolio.Output;
@@ -8,6 +8,6 @@ export interface CreatePortfolio {
 }
 
 export namespace CreatePortfolio {
-  export type Input = Omit<Portfolio, "id">;
+  export type Input = PortfolioDTO;
   export type Output = Portfolio;
 }

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -1,2 +1,3 @@
 export * from "./authentication";
 export * from "./create-account";
+export * from "./create-portfolio";

--- a/src/domain/errors/index.ts
+++ b/src/domain/errors/index.ts
@@ -1,2 +1,3 @@
 export * from "./account-creation-error";
 export * from "./authentication-error";
+export * from "./unexpected-error";

--- a/src/domain/errors/unexpected-error.ts
+++ b/src/domain/errors/unexpected-error.ts
@@ -1,0 +1,6 @@
+export class UnexpectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnexpectedError";
+  }
+}

--- a/src/domain/models/account.ts
+++ b/src/domain/models/account.ts
@@ -2,7 +2,7 @@ export type Account = {
   id: string;
   name: string;
   email: string;
-  image?: string;
+  image?: string | null;
 };
 
 export default Account;

--- a/src/domain/models/index.ts
+++ b/src/domain/models/index.ts
@@ -1,3 +1,4 @@
 export * from "./account";
 export * from "./oauth-user";
+export * from "./portfolio";
 export * from "./session";

--- a/src/domain/models/portfolio.ts
+++ b/src/domain/models/portfolio.ts
@@ -1,0 +1,7 @@
+export type Portfolio = {
+  id: string;
+  name: string;
+  description?: string | null;
+};
+
+export default Portfolio;

--- a/src/domain/models/portfolio.ts
+++ b/src/domain/models/portfolio.ts
@@ -4,4 +4,6 @@ export type Portfolio = {
   description?: string | null;
 };
 
+export type PortfolioDTO = Omit<Portfolio, "id"> & { accountId: string };
+
 export default Portfolio;

--- a/src/domain/usecases/create-portfolio-usecase.ts
+++ b/src/domain/usecases/create-portfolio-usecase.ts
@@ -1,0 +1,20 @@
+import { AddPortfolioRepository } from "@/domain/contracts/repositories";
+import { CreatePortfolio } from "@/domain/entities";
+import { UnexpectedError } from "@/domain/errors";
+
+type Input = CreatePortfolio.Input;
+type Output = CreatePortfolio.Output;
+
+export class CreatePortfolioUseCase implements CreatePortfolio {
+  constructor(private readonly repository: AddPortfolioRepository) {}
+
+  async create(input: Input): Promise<Output> {
+    try {
+      const account = await this.repository.add(input);
+
+      return account;
+    } catch (error) {
+      throw new UnexpectedError("Error on CreatePortfolio");
+    }
+  }
+}

--- a/src/domain/usecases/create-portfolio-usecase.ts
+++ b/src/domain/usecases/create-portfolio-usecase.ts
@@ -19,9 +19,9 @@ export class CreatePortfolioUseCase implements CreatePortfolio {
 
       this.validation.validate(name);
 
-      const account = await this.repository.add(input);
+      const portfolio = await this.repository.add(input);
 
-      return account;
+      return portfolio;
     } catch (error) {
       if (error instanceof ValidationError) {
         throw new RequiredFieldError("Invalid name field");

--- a/src/domain/usecases/create-portfolio-usecase.ts
+++ b/src/domain/usecases/create-portfolio-usecase.ts
@@ -1,19 +1,32 @@
 import { AddPortfolioRepository } from "@/domain/contracts/repositories";
 import { CreatePortfolio } from "@/domain/entities";
 import { UnexpectedError } from "@/domain/errors";
+import { Validation } from "@/validation/contracts";
+import { RequiredFieldError, ValidationError } from "@/validation/errors";
 
 type Input = CreatePortfolio.Input;
 type Output = CreatePortfolio.Output;
 
 export class CreatePortfolioUseCase implements CreatePortfolio {
-  constructor(private readonly repository: AddPortfolioRepository) {}
+  constructor(
+    private readonly repository: AddPortfolioRepository,
+    private readonly validation: Validation,
+  ) {}
 
   async create(input: Input): Promise<Output> {
     try {
+      const { name } = input;
+
+      this.validation.validate(name);
+
       const account = await this.repository.add(input);
 
       return account;
     } catch (error) {
+      if (error instanceof ValidationError) {
+        throw new RequiredFieldError("Invalid name field");
+      }
+
       throw new UnexpectedError("Error on CreatePortfolio");
     }
   }

--- a/src/domain/usecases/index.ts
+++ b/src/domain/usecases/index.ts
@@ -1,2 +1,3 @@
 export * from "./authentication-usecase";
 export * from "./create-account-usecase";
+export * from "./create-portfolio-usecase";

--- a/src/infra/db/postgresql/account-postgresql-repository.ts
+++ b/src/infra/db/postgresql/account-postgresql-repository.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { Account as PrismaAccount, PrismaClient } from "@prisma/client";
 
 import {
   AddAccountRepository,
@@ -32,12 +32,14 @@ export class AccountPostgreSqlRepository
     return this.mapToAccount(result);
   }
 
-  private mapToAccount(result: any): Account {
+  private mapToAccount(result: PrismaAccount): Account {
+    const { id, email, name, image } = result;
+
     return {
-      id: result.id,
-      email: result.email,
-      name: result.name,
-      image: result.image,
+      id,
+      email,
+      name,
+      image: image ?? undefined,
     };
   }
 }

--- a/src/infra/db/postgresql/account-postgresql-repository.ts
+++ b/src/infra/db/postgresql/account-postgresql-repository.ts
@@ -39,7 +39,7 @@ export class AccountPostgreSqlRepository
       id,
       email,
       name,
-      image: image ?? undefined,
+      image,
     };
   }
 }

--- a/src/infra/db/postgresql/portfolio-postgresql-repository.ts
+++ b/src/infra/db/postgresql/portfolio-postgresql-repository.ts
@@ -1,0 +1,33 @@
+import { PrismaClient, Portfolio as PrismaPortfolio } from "@prisma/client";
+
+import { AddPortfolioRepository } from "@/domain/contracts/repositories";
+
+import { Portfolio, PortfolioDTO } from "@/domain/models";
+
+export class PortfolioPostgreSqlRepository implements AddPortfolioRepository {
+  constructor(private readonly client: PrismaClient) {}
+
+  async add(input: PortfolioDTO): Promise<Portfolio> {
+    const { name, description, accountId } = input;
+
+    const result = await this.client.portfolio.create({
+      data: {
+        name,
+        description,
+        accountId,
+      },
+    });
+
+    return this.mapToPortfolio(result);
+  }
+
+  private mapToPortfolio(result: PrismaPortfolio): Portfolio {
+    const { id, name, description } = result;
+
+    return {
+      id,
+      name,
+      description,
+    };
+  }
+}

--- a/src/infra/index.ts
+++ b/src/infra/index.ts
@@ -1,2 +1,3 @@
 export * from "./db/db-client";
 export * from "./db/postgresql/account-postgresql-repository";
+export * from "./db/postgresql/portfolio-postgresql-repository";

--- a/tests/domain/usecases/create-portfolio-usecase.spec.ts
+++ b/tests/domain/usecases/create-portfolio-usecase.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AddPortfolioRepository } from "@/domain/contracts/repositories";
+import { CreatePortfolioUseCase } from "@/domain/usecases";
+
+import { UnexpectedError } from "@/domain/errors";
+import { ValidationError } from "@/validation/errors";
+import {
+  AddPortfolioRepositorySpy,
+  ValidationSpy,
+  makeFakePortfolioInput,
+} from "tests/mocks";
+
+type SutTypes = {
+  sut: CreatePortfolioUseCase;
+  addPortfolioRepositorySpy: AddPortfolioRepository;
+  validationSpy: ValidationSpy;
+};
+
+const makeSut = (): SutTypes => {
+  const addPortfolioRepositorySpy = new AddPortfolioRepositorySpy();
+  const validationSpy = new ValidationSpy();
+
+  const sut = new CreatePortfolioUseCase(
+    addPortfolioRepositorySpy,
+    validationSpy
+  );
+
+  return {
+    sut,
+    validationSpy,
+    addPortfolioRepositorySpy,
+  };
+};
+
+describe("Create Portfolio UseCase", () => {
+  it("should create a portfolio and return it if AddPortfolioRepository succeeds", async () => {
+    const { sut, addPortfolioRepositorySpy, validationSpy } = makeSut();
+
+    const fakePortfolioInput = makeFakePortfolioInput();
+
+    addPortfolioRepositorySpy.add = vi
+      .fn()
+      .mockResolvedValue(fakePortfolioInput);
+
+    const portfolio = await sut.create(fakePortfolioInput);
+
+    expect(portfolio).toEqual(fakePortfolioInput);
+    expect(addPortfolioRepositorySpy.add).toHaveBeenCalledWith(
+      fakePortfolioInput
+    );
+    expect(validationSpy.validate).toHaveBeenCalledWith(
+      fakePortfolioInput.name
+    );
+  });
+
+  it("should throw a ValidationError if validation fails", async () => {
+    const { sut, validationSpy } = makeSut();
+
+    vi.spyOn(validationSpy, "validate").mockImplementation(() => {
+      throw new ValidationError("Invalid name field");
+    });
+
+    const fakePortfolioInput = makeFakePortfolioInput();
+
+    const promise = sut.create(fakePortfolioInput);
+
+    await expect(promise).rejects.toThrow(ValidationError);
+    await expect(promise).rejects.toThrow("Invalid name field");
+  });
+
+  it("should throw an UnexpectedError if AddPortfolioRepository fails", async () => {
+    const { sut, addPortfolioRepositorySpy } = makeSut();
+
+    vi.spyOn(addPortfolioRepositorySpy, "add").mockRejectedValue(
+      new Error("Test error")
+    );
+
+    const fakePortfolioInput = makeFakePortfolioInput();
+
+    const promise = sut.create(fakePortfolioInput);
+
+    await expect(promise).rejects.toThrow(UnexpectedError);
+    await expect(promise).rejects.toThrow("Error on CreatePortfolio");
+  });
+});

--- a/tests/infra/db/postgresql/account-postgresql-repository.spec.ts
+++ b/tests/infra/db/postgresql/account-postgresql-repository.spec.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { OAuthUser } from "./../../../../src/domain/models/oauth-user";
 
+import { OAuthUser } from "@/domain/models/oauth-user";
 import { AccountPostgreSqlRepository } from "@/infra";
 import { mockPrismaClient } from "@/tests/mocks";
 

--- a/tests/infra/db/postgresql/portfolio-postgresql-repository.spec.ts
+++ b/tests/infra/db/postgresql/portfolio-postgresql-repository.spec.ts
@@ -1,0 +1,49 @@
+import { PrismaClient } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PortfolioPostgreSqlRepository } from "@/infra";
+
+import {
+  makeFakePortfolio,
+  makeFakePortfolioInput,
+  mockPrismaClient,
+} from "@/tests/mocks";
+
+type SutTypes = {
+  sut: PortfolioPostgreSqlRepository;
+};
+
+const makeSut = (): SutTypes => {
+  const sut = new PortfolioPostgreSqlRepository(
+    mockPrismaClient as unknown as PrismaClient
+  );
+
+  return { sut };
+};
+
+const mockPortfolioDTO = makeFakePortfolioInput();
+const mockPortfolio = makeFakePortfolio();
+
+describe("PortfolioPostgreSqlRepository", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should add a portfolio successfully", async () => {
+    const { sut } = makeSut();
+
+    mockPrismaClient.portfolio.create.mockResolvedValue(mockPortfolio);
+
+    const portfolio = await sut.add(mockPortfolioDTO);
+
+    expect(portfolio).toEqual({
+      id: mockPortfolio.id,
+      name: mockPortfolio.name,
+      description: mockPortfolio.description,
+    });
+
+    expect(mockPrismaClient.portfolio.create).toHaveBeenCalledWith({
+      data: mockPortfolioDTO,
+    });
+  });
+});

--- a/tests/mocks/data/index.ts
+++ b/tests/mocks/data/index.ts
@@ -1,2 +1,3 @@
 export * from "./mock-account";
+export * from "./mock-portfolio";
 export * from "./mock-prisma";

--- a/tests/mocks/data/mock-portfolio.ts
+++ b/tests/mocks/data/mock-portfolio.ts
@@ -1,8 +1,8 @@
 import { faker } from "@faker-js/faker";
 
-import { Portfolio } from "@/domain/models";
+import { Portfolio, PortfolioDTO } from "@/domain/models";
 
-export const makeFakePortfolioInput = (): Omit<Portfolio, "id"> => ({
+export const makeFakePortfolioInput = (): PortfolioDTO => ({
   name: "My Portfolio",
   description: "This is a sample portfolio",
 });

--- a/tests/mocks/data/mock-portfolio.ts
+++ b/tests/mocks/data/mock-portfolio.ts
@@ -3,8 +3,9 @@ import { faker } from "@faker-js/faker";
 import { Portfolio, PortfolioDTO } from "@/domain/models";
 
 export const makeFakePortfolioInput = (): PortfolioDTO => ({
-  name: "My Portfolio",
-  description: "This is a sample portfolio",
+  name: faker.finance.accountName(),
+  description: faker.lorem.paragraph(),
+  accountId: faker.string.uuid(),
 });
 
 export const makeFakePortfolio = (): Portfolio => ({

--- a/tests/mocks/data/mock-portfolio.ts
+++ b/tests/mocks/data/mock-portfolio.ts
@@ -1,0 +1,13 @@
+import { faker } from "@faker-js/faker";
+
+import { Portfolio } from "@/domain/models";
+
+export const makeFakePortfolioInput = (): Omit<Portfolio, "id"> => ({
+  name: "My Portfolio",
+  description: "This is a sample portfolio",
+});
+
+export const makeFakePortfolio = (): Portfolio => ({
+  id: faker.string.uuid(),
+  ...makeFakePortfolioInput(),
+});

--- a/tests/mocks/data/mock-prisma.ts
+++ b/tests/mocks/data/mock-prisma.ts
@@ -5,4 +5,7 @@ export const mockPrismaClient = {
     findUnique: vi.fn(),
     create: vi.fn(),
   },
+  portfolio: {
+    create: vi.fn(),
+  },
 };

--- a/tests/mocks/repositories/add-portfolio-repository-spy.ts
+++ b/tests/mocks/repositories/add-portfolio-repository-spy.ts
@@ -8,6 +8,7 @@ export class AddPortfolioRepositorySpy implements AddPortfolioRepository {
   input: PortfolioDTO = {
     name: faker.person.fullName(),
     description: faker.word.words(10),
+    accountId: faker.string.uuid(),
   };
 
   output: Portfolio = {

--- a/tests/mocks/repositories/add-portfolio-repository-spy.ts
+++ b/tests/mocks/repositories/add-portfolio-repository-spy.ts
@@ -1,0 +1,24 @@
+import { faker } from "@faker-js/faker";
+
+import { Portfolio } from "@/domain/models";
+
+import { AddPortfolioRepository } from "@/domain/contracts/repositories";
+
+export class AddPortfolioRepositorySpy implements AddPortfolioRepository {
+  input: Omit<Portfolio, "id"> = {
+    name: faker.person.fullName(),
+    description: faker.word.words(10),
+  };
+
+  output: Portfolio = {
+    id: faker.string.uuid(),
+    name: faker.person.fullName(),
+    description: faker.word.words(10),
+  };
+
+  async add(input: Omit<Portfolio, "id">): Promise<Portfolio> {
+    this.input = input;
+
+    return this.output;
+  }
+}

--- a/tests/mocks/repositories/add-portfolio-repository-spy.ts
+++ b/tests/mocks/repositories/add-portfolio-repository-spy.ts
@@ -1,11 +1,11 @@
 import { faker } from "@faker-js/faker";
 
-import { Portfolio } from "@/domain/models";
+import { Portfolio, PortfolioDTO } from "@/domain/models";
 
 import { AddPortfolioRepository } from "@/domain/contracts/repositories";
 
 export class AddPortfolioRepositorySpy implements AddPortfolioRepository {
-  input: Omit<Portfolio, "id"> = {
+  input: PortfolioDTO = {
     name: faker.person.fullName(),
     description: faker.word.words(10),
   };
@@ -16,7 +16,7 @@ export class AddPortfolioRepositorySpy implements AddPortfolioRepository {
     description: faker.word.words(10),
   };
 
-  async add(input: Omit<Portfolio, "id">): Promise<Portfolio> {
+  async add(input: PortfolioDTO): Promise<Portfolio> {
     this.input = input;
 
     return this.output;

--- a/tests/mocks/repositories/index.ts
+++ b/tests/mocks/repositories/index.ts
@@ -1,2 +1,3 @@
 export * from "./add-account-repository-spy";
+export * from "./add-portfolio-repository-spy";
 export * from "./load-account-by-email-repository-spy";

--- a/tests/mocks/validation/validation-spy.ts
+++ b/tests/mocks/validation/validation-spy.ts
@@ -1,13 +1,6 @@
 import { Validation } from "@/validation/contracts";
+import { vi } from "vitest";
 
 export class ValidationSpy implements Validation {
-  error: Error | null = null;
-  input: any;
-
-  validate(input: any): void {
-    this.input = input;
-    if (this.error) {
-      throw this.error;
-    }
-  }
+  validate = vi.fn();
 }


### PR DESCRIPTION
### Título: Adicionar Recurso de Criação de Portfólio

### Descrição

Este PR introduz o recurso "Criar Portfólio" na nossa aplicação, permitindo aos usuários adicionar novos portfólios às suas contas. Esta adição abrange atualizações em modelos de domínio, interfaces de repositório, implementação de caso de uso, e a camada de repositório para suportar a criação de portfólios. Testes abrangentes foram adicionados para garantir a confiabilidade e funcionalidade do recurso.

### Mudanças

- **Modelos de Domínio**:
  - Adicionados os tipos `Portfolio` e `PortfolioDTO` para representar os dados de portfólio dentro da aplicação.

- **Contratos/Domínio/Repositórios**:
  - Introduzida a interface `AddPortfolioRepository` para abstrair a adição de portfólios.

- **Casos de Uso**:
  - Implementado `CreatePortfolioUseCase`, encapsulando a lógica de negócios para criação de portfólio.

- **Infraestrutura**:
  - Implementado `PortfolioPostgreSqlRepository` para a interface `AddPortfolioRepository`, utilizando PrismaClient para interação com o banco de dados.

- **Testes**:
  - Adicionados testes unitários para `PortfolioPostgreSqlRepository` para validar a funcionalidade de adição do repositório.

- **Esquema Prisma**:
  - Atualizado o esquema do Prisma para incluir o modelo `Portfolio`, relacionando-o ao modelo `Account` através de `accountId`.

### Detalhes da Implementação

O recurso foi construído seguindo os princípios da arquitetura limpa, assegurando a separação de preocupações e a testabilidade. O caso de uso interage com a camada de repositório através de uma interface bem definida, e as operações reais do banco de dados são encapsuladas dentro do `PortfolioPostgreSqlRepository`. Este repositório usa o Prisma ORM para manipulação de dados, garantindo segurança de tipo e simplificando interações com o banco de dados.

### Testes

O recurso vem acompanhado de uma suíte de testes unitários cobrindo os caminhos críticos da criação de portfólio. Esses testes utilizam `vitest` para a execução dos testes e `vi` para simulação de dependências, incluindo o PrismaClient. Os testes asseguram que os portfólios são corretamente adicionados ao banco de dados e lidam com potenciais casos de erro de maneira elegante.

### Como Testar Manualmente

1. Garanta que o banco de dados esteja funcionando e a aplicação esteja corretamente configurada para se conectar a ele.
2. Use o endpoint (fornecer detalhes ou referenciar documentação) para criar um novo portfólio, fornecendo as informações necessárias (nome, descrição, accountId).
3. Verifique se o portfólio foi corretamente adicionado ao banco de dados e associado à conta correta.
